### PR TITLE
POC of LESC

### DIFF
--- a/adapter_nrf528xx-full.go
+++ b/adapter_nrf528xx-full.go
@@ -101,9 +101,55 @@ func handleEvent() {
 			C.sd_ble_gap_phy_update(gapEvent.conn_handle, &phyUpdateRequest.peer_preferred_phys)
 		case C.BLE_GAP_EVT_AUTH_STATUS:
 			// here we get auth response
+			if debug {
+				authStatus := gapEvent.params.unionfield_auth_status()
+				if authStatus.auth_status != C.BLE_GAP_SEC_STATUS_SUCCESS {
+					if authStatus.bitfield_error_src() == C.BLE_GAP_SEC_STATUS_SOURCE_LOCAL {
+						println("auth failed from local source")
+					} else {
+						println("auth failed from remote source")
+					}
+					println("auth status failed with status:", authStatus.auth_status)
+					break
+				}
+				if authStatus.bitfield_bonded() == 1 {
+					println("auth status is bonded")
+				}
+				if authStatus.bitfield_lesc() == 1 {
+					println("connection is LE secure")
+				}
+				if authStatus.kdist_own.bitfield_enc() != 0 {
+					println("local peer distributed encription keys")
+				}
+				if authStatus.kdist_own.bitfield_id() != 0 {
+					println("local peer distributed id keys")
+				}
+				if authStatus.kdist_own.bitfield_sign() != 0 {
+					println("local peer distributed sign keys")
+				}
+				if authStatus.kdist_own.bitfield_link() != 0 {
+					println("local peer distributed link keys")
+				}
+
+				if authStatus.kdist_peer.bitfield_enc() != 0 {
+					println("remote peer distributed encription keys")
+				}
+				if authStatus.kdist_peer.bitfield_id() != 0 {
+					println("remote peer distributed id keys")
+				}
+				if authStatus.kdist_peer.bitfield_sign() != 0 {
+					println("remote peer distributed sign keys")
+				}
+				if authStatus.kdist_peer.bitfield_link() != 0 {
+					println("remote peer distributed link keys")
+				}
+			}
+
 			// TODO: save keys to flash for pairing/bonding
 		case C.BLE_GAP_EVT_PHY_UPDATE:
 		// ignore confirmation of phy successfully updated
+		case C.BLE_GAP_EVT_CONN_SEC_UPDATE:
+
 		case C.BLE_GAP_EVT_SEC_PARAMS_REQUEST:
 			if debug {
 				println("evt: security parameters request")
@@ -123,9 +169,13 @@ func handleEvent() {
 			}
 
 		case C.BLE_GAP_EVT_LESC_DHKEY_REQUEST:
-		// TODO: for LESC connection implementation
-		// 	peerPk := eventBuf.evt.unionfield_gatts_evt()
-		// 	sd_ble_gap_lesc_dhkey_reply(gapEvent.conn_handle, ble_gap_lesc_dhkey_t const *p_dhkey))
+			if debug {
+				println("evt: lesc dhkey request")
+			}
+			//	lesc_request := gapEvent.params.unionfield_lesc_dhkey_request()
+			//DefaultAdapter.lescRequestHandler(lesc_request.p_pk_peer.pk[:])
+			DefaultAdapter.lescRequestHandler(secKeySet.keys_peer.p_pk.pk[:])
+
 		default:
 			if debug {
 				println("unknown GAP event:", id)

--- a/adapter_nrf528xx.go
+++ b/adapter_nrf528xx.go
@@ -47,15 +47,23 @@ func SetSecParamsBonding() {
 }
 
 func SetSecParamsLesc() {
-	secParams.set_bitfield_bond(0)
+	secParams.set_bitfield_bond(0) //1)
 	secParams.set_bitfield_lesc(1)
+	//secParams.set_bitfield_mitm(1)
+	//secParams.set_bitfield_io_caps(uint8(DisplayOnlyGapIOCapability))
 }
 
 func SetLesPublicKey(key []uint8) {
 	secKeySet.keys_peer = C.ble_gap_sec_keys_t{
-		p_pk: &C.ble_gap_lesc_p256_pk_t{},
+		p_pk:       &C.ble_gap_lesc_p256_pk_t{},
+		p_enc_key:  &C.ble_gap_enc_key_t{},
+		p_id_key:   &C.ble_gap_id_key_t{},
+		p_sign_key: &C.ble_gap_sign_info_t{},
 	}
 	secKeySet.keys_own = C.ble_gap_sec_keys_t{
+		p_enc_key:  &C.ble_gap_enc_key_t{},
+		p_id_key:   &C.ble_gap_id_key_t{},
+		p_sign_key: &C.ble_gap_sign_info_t{},
 		p_pk: &C.ble_gap_lesc_p256_pk_t{
 			pk: [C.BLE_GAP_LESC_P256_PK_LEN]uint8(key),
 		},

--- a/adapter_nrf528xx.go
+++ b/adapter_nrf528xx.go
@@ -38,25 +38,40 @@ var (
 		max_key_size: 16,
 	}
 
-	secKeySet C.ble_gap_sec_keyset_t = C.ble_gap_sec_keyset_t{
-		keys_peer: C.ble_gap_sec_keys_t{
-			p_enc_key:  &C.ble_gap_enc_key_t{},   /**< Encryption Key, or NULL. */
-			p_id_key:   &C.ble_gap_id_key_t{},    /**< Identity Key, or NULL. */
-			p_sign_key: &C.ble_gap_sign_info_t{}, /**< Signing Key, or NULL. */
-			p_pk:       &C.ble_gap_lesc_p256_pk_t{},
-		},
-		keys_own: C.ble_gap_sec_keys_t{
-			p_enc_key:  &C.ble_gap_enc_key_t{},   /**< Encryption Key, or NULL. */
-			p_id_key:   &C.ble_gap_id_key_t{},    /**< Identity Key, or NULL. */
-			p_sign_key: &C.ble_gap_sign_info_t{}, /**< Signing Key, or NULL. */
-			p_pk:       &C.ble_gap_lesc_p256_pk_t{},
-		},
-	}
+	secKeySet C.ble_gap_sec_keyset_t
 )
 
 // are those should be methods for adapter as they are relevant for sd only
 func SetSecParamsBonding() {
 	secParams.set_bitfield_bond(1)
+}
+
+func SetSecParamsLesc() {
+	secParams.set_bitfield_bond(0)
+	secParams.set_bitfield_lesc(1)
+}
+
+func SetLesPublicKey(key []uint8) {
+	secKeySet.keys_peer = C.ble_gap_sec_keys_t{
+		p_pk: &C.ble_gap_lesc_p256_pk_t{},
+	}
+	secKeySet.keys_own = C.ble_gap_sec_keys_t{
+		p_pk: &C.ble_gap_lesc_p256_pk_t{
+			pk: [C.BLE_GAP_LESC_P256_PK_LEN]uint8(key),
+		},
+	}
+}
+
+func ReplyLesc(key []byte) error {
+	lescKey := C.ble_gap_lesc_dhkey_t{
+		key: [C.BLE_GAP_LESC_DHKEY_LEN]uint8(key),
+	}
+	errCode := C.sd_ble_gap_lesc_dhkey_reply(currentConnection.Reg, &lescKey)
+	if errCode != 0 {
+		return Error(errCode)
+
+	}
+	return nil
 }
 
 func SetSecCapabilities(cap GapIOCapability) {
@@ -102,4 +117,8 @@ func (a *Adapter) Address() (MACAddress, error) {
 		return MACAddress{}, Error(errCode)
 	}
 	return MACAddress{MAC: addr.addr}, nil
+}
+
+func (a *Adapter) SetLescRequestHandler(c func(pubKey []uint8)) {
+	a.lescRequestHandler = c
 }

--- a/adapter_sd.go
+++ b/adapter_sd.go
@@ -48,7 +48,8 @@ type Adapter struct {
 	scanning          bool
 	charWriteHandlers []charWriteHandler
 
-	connectHandler func(device Address, connected bool)
+	connectHandler     func(device Address, connected bool)
+	lescRequestHandler func(pubKey []uint8)
 }
 
 // DefaultAdapter is the default adapter on the current system. On Nordic chips,
@@ -58,7 +59,11 @@ type Adapter struct {
 var DefaultAdapter = &Adapter{isDefault: true,
 	connectHandler: func(device Address, connected bool) {
 		return
-	}}
+	},
+	lescRequestHandler: func(pubKey []uint8) {
+		return
+	},
+}
 
 var eventBufLen uint16
 


### PR DESCRIPTION
POC of LESC connection

Can be done with something like that:

```
package main

import (
	"crypto/ecdh"
	"crypto/rand"
	_ "embed"
	"log"
	"machine"
	"time"

	"tinygo.org/x/bluetooth"
)



type keyEvent struct {
	layer, indx int
	state       keyboard.State
}

func main() {
	machine.InitSerial()
	var err error

	//niceview.ClearScreen()
	err = connect()
	if err != nil {
		println("failed to establish LESC connection:", err.Error())
		log.Fatal(err)
	}
	println("esteblished LESC connection")
	registerHID()
	println("registered HID")
	for {
                time.Sleep(1*time.Second)
        }
}

func connect() error {
	peerPKey := make([]byte, 0, 64)
	privLesc, err := ecdh.P256().GenerateKey(rand.Reader)
	if err != nil {
		return err
	}
	lescChan := make(chan struct{})
	bluetooth.SetSecParamsLesc()
	bluetooth.SetSecCapabilities(bluetooth.NoneGapIOCapability)
	time.Sleep(4 * time.Second)
	println("getting own pub key")
	var key []byte

	// pk := privLesc.PublicKey().Bytes()
	// pubKey := swapEndinan(pk[1:])
	bluetooth.SetLesPublicKey(swapEndinan(privLesc.PublicKey().Bytes()[1:]))
	// pubKey = nil
	println(" key is set")

	println("register lesc callback")
	adapter.SetLescRequestHandler(
		func(pubKey []byte) {
			peerPKey = pubKey
			close(lescChan)
		},
	)
	println("enabling adapter")
	err = adapter.Enable()
	if err != nil {
		return err
	}
	println("def adv")
	adv := adapter.DefaultAdvertisement()
	println("adv config")
	adv.Configure(bluetooth.AdvertisementOptions{
		LocalName: "tinygo-corne",
		ServiceUUIDs: []bluetooth.UUID{
			bluetooth.ServiceUUIDDeviceInformation,
			bluetooth.ServiceUUIDBattery,
			bluetooth.ServiceUUIDHumanInterfaceDevice,
		},
	})
	println("adv start")
	adv.Start()

	select {
	case <-lescChan:
		peerPKey = append([]byte{0x04}, swapEndinan(peerPKey)...)
		p, err := ecdh.P256().NewPublicKey(peerPKey)
		if err != nil {
			println("failed on parsing pub:", err.Error())
			return err
		}
		println("calculating ecdh")
		key, err = privLesc.ECDH(p)
		if err != nil {
			println("failed on curving:", err.Error())
			return err
		}
		println("key len:", len(key))
		return bluetooth.ReplyLesc(swapEndinan(key))
	}

}

func swapEndinan(in []byte) []byte {
	var reverse = make([]byte, len(in))
	for i, b := range in[:32] {

		reverse[31-i] = b
	}
	if len(in) > 32 {
		for i, b := range in[32:] {
			reverse[63-i] = b
		}
	}

	return reverse
}

func registerHID() {
	adapter.AddService(&bluetooth.Service{
		UUID: bluetooth.ServiceUUIDDeviceInformation,
		Characteristics: []bluetooth.CharacteristicConfig{
			{
				UUID:  bluetooth.CharacteristicUUIDManufacturerNameString,
				Flags: bluetooth.CharacteristicReadPermission,
				Value: []byte("Nice Keyboards"),
			},
			{
				UUID:  bluetooth.CharacteristicUUIDModelNumberString,
				Flags: bluetooth.CharacteristicReadPermission,
				Value: []byte("nice!nano"),
			},
			{
				UUID:  bluetooth.CharacteristicUUIDPnPID,
				Flags: bluetooth.CharacteristicReadPermission,
				Value: []byte{0x02, 0x8a, 0x24, 0x66, 0x82, 0x34, 0x36},
				//Value: []byte{0x02, uint8(0x10C4 >> 8), uint8(0x10C4 & 0xff), uint8(0x0001 >> 8), uint8(0x0001 & 0xff)},
			},
		},
	})
	adapter.AddService(&bluetooth.Service{
		UUID: bluetooth.ServiceUUIDBattery,
		Characteristics: []bluetooth.CharacteristicConfig{
			{
				UUID:  bluetooth.CharacteristicUUIDBatteryLevel,
				Value: []byte{80},
				Flags: bluetooth.CharacteristicReadPermission | bluetooth.CharacteristicNotifyPermission,
			},
		},
	})
	// gacc
	/*
	   device name r
	   apperance r
	   peripheral prefreed connection

	*/

	adapter.AddService(&bluetooth.Service{
		UUID: bluetooth.ServiceUUIDGenericAccess,
		Characteristics: []bluetooth.CharacteristicConfig{
			{
				UUID:  bluetooth.CharacteristicUUIDDeviceName,
				Flags: bluetooth.CharacteristicReadPermission,
				Value: []byte("tinygo-corne"),
			},
			{

				UUID:  bluetooth.New16BitUUID(0x2A01),
				Flags: bluetooth.CharacteristicReadPermission,
				Value: []byte{uint8(0x03c4 >> 8), uint8(0x03c4 & 0xff)}, /// []byte(strconv.Itoa(961)),
			},
			// {
			// 	UUID:  bluetooth.CharacteristicUUIDPeripheralPreferredConnectionParameters,
			// 	Flags: bluetooth.CharacteristicReadPermission,
			// 	Value: []byte{0x02},
			// },

			// // 		//
		},
	})

	//v := []byte{0x85, 0x02} // 0x85, 0x02
	reportValue := []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}

	//var reportmap bluetooth.Characteristic

	// hid
	adapter.AddService(&bluetooth.Service{
		UUID: bluetooth.ServiceUUIDHumanInterfaceDevice,
		/*
			 - hid information r
			 - report map r
			 - report nr
			   - client charecteristic configuration
			   - report reference
			- report nr
			   - client charecteristic configuration
			   - report reference
			- hid control point wnr
		*/
		Characteristics: []bluetooth.CharacteristicConfig{
			// {
			// 	UUID:  bluetooth.CharacteristicUUIDHIDInformation,
			// 	Flags: bluetooth.CharacteristicReadPermission,
			// 	Value: []byte{uint8(0x0111 >> 8), uint8(0x0111 & 0xff), uint8(0x0002 >> 8), uint8(0x0002 & 0xff)},
			// },
			{
				//Handle: &reportmap,
				UUID:  bluetooth.CharacteristicUUIDReportMap,
				Flags: bluetooth.CharacteristicReadPermission,
				Value: reportMap,
			},
			{

				Handle: &reportIn,
				UUID:   bluetooth.CharacteristicUUIDReport,
				Value:  reportValue[:],
				Flags:  bluetooth.CharacteristicReadPermission | bluetooth.CharacteristicNotifyPermission,
			},
			{
				// protocl mode
				UUID:  bluetooth.New16BitUUID(0x2A4E),
				Flags: bluetooth.CharacteristicWriteWithoutResponsePermission | bluetooth.CharacteristicReadPermission,
				// Value: []byte{uint8(1)},
				// WriteEvent: func(client bluetooth.Connection, offset int, value []byte) {
				// 	print("protocol mode")
				// },
			},
			{
				UUID:  bluetooth.CharacteristicUUIDHIDControlPoint,
				Flags: bluetooth.CharacteristicWriteWithoutResponsePermission,
				//	Value: []byte{0x02},
			},
		},
	})
}
```



